### PR TITLE
compatibility with abstract class pattern

### DIFF
--- a/lib/sequel_enum.rb
+++ b/lib/sequel_enum.rb
@@ -2,13 +2,13 @@ module Sequel
   module Plugins
     module Enum
       def self.apply(model, opts = OPTS)
-        model.instance_eval do
-          @enums = {}
-        end
       end
 
       module ClassMethods
-        attr_reader :enums
+        
+        def enums
+          @enums ||= {}
+        end
 
         def enum(column, values)
           if values.is_a? Hash

--- a/spec/sequel_enum_spec.rb
+++ b/spec/sequel_enum_spec.rb
@@ -4,12 +4,23 @@ class Item < Sequel::Model
   plugin :enum
 end
 
+AbstractModel = Class.new(Sequel::Model)
+AbstractModel.require_valid_table = false
+AbstractModel.plugin :enum
+
+class RealModel < AbstractModel; end
+
 describe "sequel_enum" do
   let(:item) { Item.new }
 
   specify "class should provide reflection" do
     Item.enum :condition, [:mint, :very_good, :fair]
     expect(Item.enums).to eq({ condition: { :mint => 0, :very_good => 1, :fair => 2}})
+  end
+
+  specify "inheriting from abstract model should provide reflection" do
+    RealModel.enum :condition, [:mint, :very_good, :fair]
+    expect(RealModel.enums).to eq({ condition: { :mint => 0, :very_good => 1, :fair => 2}})
   end
 
   specify "it accepts an array of symbols" do


### PR DESCRIPTION
There's an abstract class pattern for Sequel that Jeremy has posted in various places (the google group, GitHub issues). However, sequel_enum doesn't work properly when used with this pattern.

This PR fixes it without changing the usage at all. The specs contain an example of this as well. The error with the pattern occurred on class load, so checking the reflections should be sufficient to ensure it is loaded correctly.