### PR TITLE
Add class method to expose the mappings of the enum.

### DIFF
--- a/lib/sequel_enum.rb
+++ b/lib/sequel_enum.rb
@@ -1,3 +1,5 @@
+require "active_support/core_ext/string"
+
 module Sequel
   module Plugins
     module Enum
@@ -5,22 +7,27 @@ module Sequel
       end
 
       module ClassMethods
-        
         def enums
           @enums ||= {}
         end
 
         def enum(column, values)
+          klass = self
+          enum_values = {}
+
           if values.is_a? Hash
             values.each do |key,val|
               raise ArgumentError, "index should be a symbol, #{key} provided which it's a #{key.class}" unless key.is_a? Symbol
               raise ArgumentError, "value should be an integer, #{val} provided which it's a #{val.class}" unless val.is_a? Integer
+              enum_values[key] = val
             end
           elsif values.is_a? Array
-            values = Hash[values.map.with_index { |v, i| [v, i] }]
+            values.each_with_index { |name, i| enum_values[name] = i }
           else
             raise ArgumentError, "#enum expects the second argument to be an array of symbols or a hash like { :symbol => integer }"
           end
+
+          klass.singleton_class.send(:define_method, column.to_s.pluralize) { enum_values }
 
           define_method "#{column}=" do |value|
             val = self.class.enums[column].assoc(value.to_sym)
@@ -32,13 +39,14 @@ module Sequel
             val && val.first
           end
 
-          values.each do |key, value|
+
+          enum_values.each do |key, value|
             define_method "#{key}?" do
               self.send(column) == key
             end
           end
 
-          self.enums[column] = values
+          self.enums[column] = enum_values
         end
       end
     end

--- a/sequel_enum.gemspec
+++ b/sequel_enum.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "sequel"
+  spec.add_runtime_dependency "activesupport", "~> 5.0"
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "bundler", "~> 1.14"

--- a/spec/sequel_enum_spec.rb
+++ b/spec/sequel_enum_spec.rb
@@ -50,7 +50,20 @@ describe "sequel_enum" do
   describe "methods" do
     before(:all) do
       Item.enum :condition, [:mint, :very_good, :good, :poor]
-      Item.enum :edition, [:first, :second, :rare, :other]
+      Item.enum :edition, {first: 0, second: 1, rare: 2, other: 3}
+    end
+
+    context "list enums of a column" do
+      describe ".conditions" do
+        it "return the enum list options defined for condition" do
+          expect(Item.conditions).to eq({mint: 0, very_good: 1, good: 2, poor: 3})
+        end
+      end
+      describe ".editions" do
+        it "return the enum list options defined for condition" do
+          expect(Item.editions).to eq({first: 0, second: 1, rare: 2, other: 3})
+        end
+      end
     end
 
     describe "#initialize_set" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,19 +2,17 @@ require 'sequel'
 require 'sqlite3'
 require 'sequel_enum'
 
-DB = Sequel.connect('sqlite://test.db')
-
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.order = 'random'
 
-  config.before(:suite) do
-    DB.create_table :items do
-      primary_key :id
-      column :name, String
-      column :condition, Integer
-      column :edition, Integer
-    end
+  DB = Sequel.sqlite
+
+  DB.create_table :items do
+    primary_key :id
+    column :name, String
+    column :condition, Integer
+    column :edition, Integer
   end
 
   config.after(:suite) do


### PR DESCRIPTION
# What is this PR for?

This PR is for adding a class method that will allow returning the enum mappings of a specific column.

For example.

```ruby
class Item < Sequel::Model
  plugin :enum
  enum :condition, { mint: 10, good: 11, poor: 15 }
end 

Item.conditions # => { mint: 10, good: 11, poor: 15 }
```
